### PR TITLE
fix(core): add default value for `spacings` and `colors`

### DIFF
--- a/packages/core/src/store.ts
+++ b/packages/core/src/store.ts
@@ -61,6 +61,8 @@ export class Store {
     ],
     theme: {
       breakpoints: {},
+      colors: {},
+      spacings: {},
     } as Theme,
     plugins: [],
   } as Configuration


### PR DESCRIPTION
`spacings` 和 `colors` 分别在以下代码引用到，如果直接使用 `@fower/core`，未引入 preset 时，会出现 `Uncaught TypeError: Cannot read properties of undefined` 错误

https://github.com/forsigner/fower/blob/master/packages/core/src/atom.ts#L322

https://github.com/forsigner/fower/blob/master/packages/core/src/parser.ts#L575